### PR TITLE
explicitly set version attribute, increment version_scheme

### DIFF
--- a/Formula/sensu-go.rb
+++ b/Formula/sensu-go.rb
@@ -1,5 +1,6 @@
 class SensuGo < Formula
-    version = '5.14.0'
+    version '5.14.0'
+    version_scheme 1
     desc "Sensu Go"
     homepage "https://sensu.io"
     url "https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/#{version}/sensu-go_#{version}_darwin_amd64.tar.gz"


### PR DESCRIPTION
Due to the way our artifacts are named, Homebrew is currently detecting the version as `64`. 

As such, we need to explicitly specify the version (was previously being used as a variable) and increment the `version_scheme` so that version 5.x is treated as newer than version `64`.

This pull request implements both changes and has worked in local testing for new installs as well as upgrades.